### PR TITLE
travis: use opam-street to setup opam (Fixes build)

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -20,7 +20,7 @@ echo OPAM versions
 opam --version
 opam --git-version
 
-opam init
+(cd $HOME && curl "https://s3.amazonaws.com/opam-street/opam-street.tar.gz" | tar xz)
 eval `opam config env`
 opam install ${OPAM_DEPENDS}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ script: bash -ex .travis-ci.sh
 env:
   global:
     - OPAM_DEPENDS="ocamlgraph"
-    - FRENETIC_DEPENDS="ocaml-packet"
+    - FRENETIC_DEPENDS="ocaml-packet core"
   matrix:
     - OCAML_VERSION=4.01.0 OPAM_VERSION=1.1.0
 notifications:


### PR DESCRIPTION
Core is now a dependency of ocaml-topology, so add it as such in .travis.yml and use opam-street in .travis-ci.sh to speed up the build.
